### PR TITLE
Add Google Apps Script version

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ upload form served from `/upload_form`.
 
 Feel free to modify or extend the bot to fit your workflow.
 
+## Google Apps Script Version
+
+A simplified Google Apps Script implementation is available in the `apps_script` folder. Create a new project at <https://script.google.com>, copy in `Code.gs`, and replace the default manifest with `appsscript.json`. Deploy the project as a **Chat app**. When the bot is first added to a space it instructs users to download the compiled OpenRV release from the [Google Drive link](https://drive.google.com/file/d/1SFsldpD9mWzKTm9tEKVhW-HwzB8tmC-8/view?usp=sharing) and run `rv -network` from the `bin` folder before interacting with the bot.
+
+
 ## Hosting on Google Cloud Run
 
 The repository includes a `Dockerfile` so the bot can run on Google Cloud Run.

--- a/apps_script/Code.gs
+++ b/apps_script/Code.gs
@@ -1,0 +1,25 @@
+function onAddToSpace(e) {
+  return {
+    text: 'Thanks for installing OpenRV Bot. Download the compiled RV from https://drive.google.com/file/d/1SFsldpD9mWzKTm9tEKVhW-HwzB8tmC-8/view?usp=sharing, place it in a folder, and run `rv -network` from the `bin` directory before using this bot.'
+  };
+}
+
+function onRemoveFromSpace(e) {
+  return {text: 'OpenRV Bot removed from this space.'};
+}
+
+function onMessage(e) {
+  var text = '';
+  if (e.message) {
+    text = e.message.text || e.message.argumentText || '';
+  }
+  var match = text.match(/gs:\/\/[\S]+/);
+  if (match) {
+    return {
+      text: 'Received sequence URL: ' + match[0] + '\nDownload it locally and use `rvpush` to open the sequence in your running RV session.'
+    };
+  }
+  return {
+    text: 'Mention @OpenRV Bot with a `gs://` URL to view a sequence. Uploading files is not implemented in this Apps Script example.'
+  };
+}

--- a/apps_script/appsscript.json
+++ b/apps_script/appsscript.json
@@ -1,0 +1,8 @@
+{
+  "timeZone": "UTC",
+  "chat": {
+    "name": "OpenRV Bot",
+    "description": "Upload image sequences and open them in OpenRV",
+    "avatarUrl": "https://developers.google.com/chat/images/quickstart-app-avatar.png"
+  }
+}


### PR DESCRIPTION
## Summary
- add Google Apps Script implementation in `apps_script`
- document how to use the Apps Script version

## Testing
- `python -m py_compile scripts/google_chat_bot.py`

------
https://chatgpt.com/codex/tasks/task_b_6885bffcc798832997541dd87ca91330